### PR TITLE
Node 24 fix

### DIFF
--- a/.github/actions/setup-base/action.yml
+++ b/.github/actions/setup-base/action.yml
@@ -34,10 +34,10 @@ runs:
   using: "composite"
   steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/actions/setup-docker-base/action.yml
+++ b/.github/actions/setup-docker-base/action.yml
@@ -64,7 +64,7 @@ runs:
   using: "composite"
   steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup SSH agent
       uses: datagenie-ai/.github/.github/actions/setup-ssh-agent@main
@@ -84,19 +84,19 @@ runs:
         fi
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ inputs.registry-username }}
         password: ${{ inputs.registry-password }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     # Build and push (with SSH)
     - name: Build and push Docker image (with SSH, no-cache)
       if: inputs.ssh-key != '' && inputs.no-cache == 'true'
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.context }}
         push: true
@@ -110,7 +110,7 @@ runs:
 
     - name: Build and push Docker image (with SSH, cached)
       if: inputs.ssh-key != '' && inputs.no-cache != 'true'
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.context }}
         push: true
@@ -126,7 +126,7 @@ runs:
     # Build and push (no SSH)
     - name: Build and push Docker image (no SSH, no-cache)
       if: inputs.ssh-key == '' && inputs.no-cache == 'true'
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.context }}
         push: true
@@ -138,7 +138,7 @@ runs:
 
     - name: Build and push Docker image (no SSH, cached)
       if: inputs.ssh-key == '' && inputs.no-cache != 'true'
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.context }}
         push: true

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -44,10 +44,10 @@ runs:
         repo-host-config: ${{ inputs.repo-host-config }}
 
     - name: Run Ruff Lint
-      uses: astral-sh/ruff-action@v3
+      uses: astral-sh/ruff-action@v4
 
     - name: Run Ruff Format Check
-      uses: astral-sh/ruff-action@v3
+      uses: astral-sh/ruff-action@v4
       with:
         args: "format --check"
 


### PR DESCRIPTION
## Type of Change
- [ ] 🔥 Has Breaking changes
- [ ] 🎉 New features/enhancements
- [ ] 🐛 Bug fixes
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🛠️ Tests
- [x] 👷🏽 CICD

## 👷🏽 CICD
Bump all Node 20 GitHub Actions to their Node 24 releases across the shared composite actions, ahead of GitHub's 2026-06-16 forced migration (Node 20 will be removed from runners on 2026-09-16).

## Node 24 fix — `datagenie-ai/.github` composite action changes

| File | Step | Action | Before (Node 20) | After (Node 24) |
|------|------|--------|--------|-------|
| `.github/actions/setup-base/action.yml` | Check out code | actions/checkout | v4 | v6 |
| `.github/actions/setup-base/action.yml` | Setup Python | actions/setup-python | v5 | v6 |
| `.github/actions/setup-docker-base/action.yml` | Check out code | actions/checkout | v4 | v6 |
| `.github/actions/setup-docker-base/action.yml` | Login to GHCR | docker/login-action | v3 | v4 |
| `.github/actions/setup-docker-base/action.yml` | Set up Docker Buildx | docker/setup-buildx-action | v3 | v4 |
| `.github/actions/setup-docker-base/action.yml` | Build and push (×4) | docker/build-push-action | v6 | v7 |
| `.github/actions/unit-test/action.yml` | Run Ruff Lint | astral-sh/ruff-action | v3 | v4 |
| `.github/actions/unit-test/action.yml` | Run Ruff Format Check | astral-sh/ruff-action | v3 | v4 |

**Left unchanged (no Node runtime):**
- `snok/install-poetry@v1` — composite action
- `docker/scout-action@v1` — container action

All bumped versions run on Node 24. After these changes there are no Node 20 JS actions left in the repo.