### PR TITLE
Node 24 fix

### DIFF
--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -44,10 +44,10 @@ runs:
         repo-host-config: ${{ inputs.repo-host-config }}
 
     - name: Run Ruff Lint
-      uses: astral-sh/ruff-action@v4
+      uses: astral-sh/ruff-action@v4.0.0
 
     - name: Run Ruff Format Check
-      uses: astral-sh/ruff-action@v4
+      uses: astral-sh/ruff-action@v4.0.0
       with:
         args: "format --check"
 


### PR DESCRIPTION
## Type of Change
- [ ] 🔥 Has Breaking changes
- [ ] 🎉 New features/enhancements
- [x] 🐛 Bug fixes
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🛠️ Tests
- [x] 👷🏽 CICD

## 🐛 Bug fixes
`astral-sh/ruff-action` uses `major.minor.patch` since `v4` so replaced `v4` with `4.0.0` as per GitHub documentation.